### PR TITLE
fix: parseIPv6 return extra leading 16byte.

### DIFF
--- a/parser_linux.go
+++ b/parser_linux.go
@@ -210,7 +210,7 @@ func parseIPv6(ips string) (net.IP, error) {
 			return nil, err
 		}
 
-		ip = binary.LittleEndian.AppendUint32(ip, uint32(v))
+		binary.LittleEndian.PutUint32(ip[i*4:], uint32(v))
 	}
 	return ip, nil
 }


### PR DESCRIPTION
```
ip := make([]byte, net.IPv6len)
...
ip = binary.LittleEndian.AppendUint32(ip, uint32(v))
```
will cause extra leading 16byte in net.IP